### PR TITLE
Build ARM64 wheels on MacOs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Build wheel
         run: python -m cibuildwheel --output-dir dist
         env:
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_ARCHS_MACOS: "x86_64 arm64" 
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,8 @@ jobs:
 
       - name: Build wheel
         run: python -m cibuildwheel --output-dir dist
+        env:
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Solve issue #22 by building ARM64 wheels on MacOs for Mac Apple Silicon M1/M2 processors