### PR TITLE
include mac arm64 build in PyPI upload

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -171,6 +171,11 @@ jobs:
           name: cibw-wheels-macos-13
           path: dist
 
+      - uses: actions/download-artifact@master
+        with:
+          name: cibw-wheels-macos-14
+          path: dist
+
       - run: ls dist
 
       - name: Upload to PyPI


### PR DESCRIPTION
Although Apple Silicone version (macos arm64) is [built in the release pipeline](https://github.com/aiplan4eu/up-fast-downward/blob/59f9d5fc9ebc84f7c96963ce459f821e64114447/.github/workflows/main.yml#L33-L54),
it is NOT included in [the publish-to-PyPI step](https://github.com/aiplan4eu/up-fast-downward/blob/59f9d5fc9ebc84f7c96963ce459f821e64114447/.github/workflows/main.yml#L153), and therefore is [not available on PyPI](https://pypi.org/project/up-fast-downward/0.5.0/#files).

To fix this, macos arm64 wheel should be included in the [deploy-pypi](https://github.com/aiplan4eu/up-fast-downward/blob/59f9d5fc9ebc84f7c96963ce459f821e64114447/.github/workflows/main.yml#L153-L154) action