### PR TITLE
Deploy also macos-arm64 wheel on pypi for future releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -171,6 +171,11 @@ jobs:
           name: cibw-wheels-macos-13
           path: dist
 
+      - uses: actions/download-artifact@master
+        with:
+          name: cibw-wheels-macos-14
+          path: dist
+
       - run: ls dist
 
       - name: Upload to PyPI


### PR DESCRIPTION
Will fix #32 for future relases. (Not for current 0.5.0)